### PR TITLE
ci(docs): add Bazel cache

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,6 +24,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache Bazel
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/bazel
+          key: bazel-docs-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock') }}
+          restore-keys: bazel-docs-
+
       - name: Generate API docs
         run: |
           bazel build //docs:rules_doc


### PR DESCRIPTION
Cache Bazel build outputs to speed up Stardoc generation.