### PR TITLE
ci: use bazel 8.x for docs deploy

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,6 +21,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      USE_BAZEL_VERSION: 8.x
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
stardoc 0.8.1 stamp_detector visibility bug on bazel 7